### PR TITLE
Fixed requestPath

### DIFF
--- a/Nemo Connect/Sources/NCWebService+DynamicMethod.m
+++ b/Nemo Connect/Sources/NCWebService+DynamicMethod.m
@@ -171,7 +171,8 @@
     {
         if (serviceQueryPath)
         {
-            requestPath = [requestPath stringByAppendingPathComponent:serviceQueryPath];
+            NSURL *requestURL = [self.serviceRootURL URLByAppendingPathComponent:serviceQueryPath];
+            requestPath = [requestURL absoluteString];
         }
     }
     else


### PR DESCRIPTION
Using URLByAppendingPathComponent instead of stringByAppendingPathComponent so that double slashes following URL Scheme does not get truncated
